### PR TITLE
Fix for lru-cache > 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - 0.10
+sudo: false

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function Locking(loader, options) {
         var key = JSON.stringify(id);
 
         // Instance is in LRU cache.
-        var cached = cache.get(key);
+        var cached = cache.peek(key);
         if (cached) {
             cacheStats.hit++;
             return callback(null, cached);


### PR DESCRIPTION
Switches from `cache.get` to `cache.peek` so that objects requested frequently actually expire (Background: https://github.com/isaacs/node-lru-cache/issues/43). Per lru-cache README, we may be using the wrong type of cache here but that's a quest for another day.