### PR TITLE
Ensure object is not cached on errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function locking(loader, options) {
         locks[key] = [callback];
 
         loader(id, function(err, instance) {
-            if (instance) {
+            if (!err && instance) {
                 cacheStats.miss++;
                 cache.set(key, instance);
             }

--- a/test.js
+++ b/test.js
@@ -14,6 +14,10 @@ var testRead = function(id, callback) {
         io[JSON.stringify(id)]++;
         var data = JSON.parse(JSON.stringify(doc));
         data.id = id;
+        // This purposefully simulates an I/O source that passes an error
+        // object *and* futher args to the callback. While most I/O functions
+        // don't pass anything beyond an error on failures when they do we
+        // need to bypass caching.
         if (id === 'err') {
             callback(new Error('read fail'), data);
         } else {

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ var doc = {};
 var io = {};
 io['"a"'] = 0;
 io['"b"'] = 0;
+io['"err"'] = 0;
 
 // Simulates a read function of the form `read(id, callback)`
 var testRead = function(id, callback) {
@@ -13,7 +14,11 @@ var testRead = function(id, callback) {
         io[JSON.stringify(id)]++;
         var data = JSON.parse(JSON.stringify(doc));
         data.id = id;
-        callback(null, data);
+        if (id === 'err') {
+            callback(new Error('read fail'), data);
+        } else {
+            callback(null, data);
+        }
     }, 100);
 };
 
@@ -28,6 +33,24 @@ tape('locking singletons', function(t) {
 tape('accepts object as id', function(t) {
     reader({pathname:'/test'}, function(err, read) {
         t.deepEqual(read, { id: { pathname: '/test' } }, 'returns read object');
+        t.end();
+    });
+});
+
+tape('passes errors', function(t) {
+    reader('err', function(err, read) {
+        t.equal(err.toString(), 'Error: read fail');
+        t.deepEqual(read, { id: 'err' });
+        t.deepEqual(io['"err"'], 1, 'iops: 1');
+        t.end();
+    });
+});
+
+tape('does not cache object on errors', function(t) {
+    reader('err', function(err, read) {
+        t.equal(err.toString(), 'Error: read fail');
+        t.deepEqual(read, { id: 'err' });
+        t.deepEqual(io['"err"'], 2, 'iops: 2');
         t.end();
     });
 });


### PR DESCRIPTION
:flushed:

- In `master` *most* I/O caches are dodging being cached in error cases because they do not pass back any further arguments than the error to the callback. https://github.com/mapbox/node-locking/blob/a52f18f8e9508b3ba2087a4df2130ec0a0b35855/index.js#L43-L46
- There was no testcase for what happens when an error *and* instance of data is passed back. First testrun at https://travis-ci.org/mapbox/node-locking/builds/80168764 demonstrates how master currently will
  - Set the cache, pass an error back on first call
  - Pass the data back on the second call as if it were a cache-hit, with no error
- Fix: If there is an error at all we avoid setting the cache.

cc @willwhite @ianshward @emilymcafee 
