### PR TITLE
bump lru-cache to v4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - 0.10
+  - 4
 sudo: false

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function locking(loader, options) {
         var key = JSON.stringify(id);
 
         // Instance is in LRU cache.
-        var cached = cache.peek(key);
+        var cached = cache.get(key);
         if (cached) {
             cacheStats.hit++;
             return callback(null, cached);

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "lru-cache": "^4.0.1"
   },
   "devDependencies": {
-    "tape": "3.0.x",
-    "eslint": "~1.00.0",
-    "eslint-config-unstyled": "^1.1.0"
+    "eslint": "^2.11.1",
+    "eslint-config-unstyled": "^1.1.0",
+    "tape": "^4.5.1"
   },
   "scripts": {
     "test": "eslint index.js && tape test.js"

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   },
   "version": "2.0.2",
   "main": "./index",
-  "engines": {
-    "node": "0.10.x"
-  },
   "dependencies": {
     "lru-cache": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": "0.10.x"
   },
   "dependencies": {
-    "lru-cache": "2.5.x"
+    "lru-cache": "^4.0.1"
   },
   "devDependencies": {
     "tape": "3.0.x",


### PR DESCRIPTION
Closes #4 

- Reverts #2 (and restores LRUness!) as this functionality has been fixed upstream.
- ~~Drops `JSON.stringify`, as lru-cache fully supports non-string keys - **is this a desirable change?**~~

TODO:
- [x] Add Node.js v4.x to CI
- [x] Update `engines` in `package.json`